### PR TITLE
fix(WL-65): resolve failed to read `.png` signature in release mode

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,6 +70,7 @@ android {
 
   buildTypes {
     release {
+      crunchPngs false
       minifyEnabled false
     }
   }


### PR DESCRIPTION
## Summary

Failed to read `.png` signature in [release](https://stackoverflow.com/questions/46177560/failed-to-read-png-signature-file-does-not-start-with-png-signature) mode.

### Android

- [x] Added `crunchPngs` as `false` on build type release for Android.